### PR TITLE
Allow "lazy" lookup of translations without printin Translation missing:

### DIFF
--- a/lib/phlex/rails/helpers.rb
+++ b/lib/phlex/rails/helpers.rb
@@ -1149,8 +1149,25 @@ module Phlex::Rails::Helpers
 	module T
 		extend Phlex::Rails::HelperMacros
 
-		# @!method t(...)
-		define_value_helper :t
+		def self.included(base)
+			base.extend(ClassMethods)
+		end
+
+		module ClassMethods
+			def translation_path
+				@translation_path ||= name&.dup.tap do |n|
+					n.gsub!("::", ".")
+					n.gsub!(/([a-z])([A-Z])/, '\1_\2')
+					n.downcase!
+				end
+			end
+		end
+
+		def t(key, **options)
+			key = "#{self.class.translation_path}#{key}" if key.start_with?(".")
+
+			helpers.t(key, **options)
+		end
 	end
 
 	module TelephoneField


### PR DESCRIPTION
The #t method in Rails views doesn't replace the missing translation with a "Translation missing:" message, but rather returns the key itself, wrapped into a span with the CSS class `translation_missing`.

Suggested reading:
https://guides.rubyonrails.org/i18n.html#lazy-lookup
https://guides.rubyonrails.org/i18n.html#using-different-exception-handlers